### PR TITLE
Feat/m1 mac support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 project/target/
 out/
+.bloop
+.vscode
+.metals

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ## Projektin kääntäminen ja suorittaminen
 
-1. Asenna sbt-projektin riippuvuudet
-2. Luo uusi ajokonfiguraatio tiedostolle `src/main/scala/main.scala`
-   - Projektia on kehitetty Javan versiolla 17
+Tarvittavat työkalut: Java SDK 21, sbt
+
+1. Kloonaa projekti
+2. `sbt run`
 
 ## Kurssin assistentille
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Projektin kääntäminen ja suorittaminen
 
-Tarvittavat työkalut: Java SDK 21, sbt
+Tarvittavat työkalut:
 
-1. Kloonaa projekti
-2. `sbt run`
+- Java SDK 21
+- [sbt](https://www.scala-sbt.org/)
+
+projektin voi kääntyy ja käynnistää komennolla `sbt run`.
 
 ## Kurssin assistentille
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,33 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "3.2.2"
+fork := true
 
 lazy val root = (project in file("."))
   .settings(
     name := "Visualization",
   )
 
-val lwjglVersion = "3.3.1"
+val lwjglVersion = "3.3.3"
 val jomlVersion = "1.10.5"
 val scalatestVersion = "3.2.15"
 val snakeYamlVersion = "1.33"
-
+val archString = if (System.getProperty("os.arch") == "aarch64") "-arm64" else ""
 val lwjglNatives = System.getProperty("os.name") match {
-  case n if n.startsWith("Linux")   => "natives-linux"
-  case n if n.startsWith("Mac")     => "natives-macos"
-  case n if n.startsWith("Windows") => "natives-windows"
+  case n if n.startsWith("Linux")   => s"natives-linux$archString"
+  case n if n.startsWith("Mac")     => s"natives-macos$archString"
+  case n if n.startsWith("Windows") => s"natives-windows$archString"
   case _                            => throw new Exception("Unknown platform!")
 }
 
+// add -XstartOnFirstThread to JVM options on macOS, see https://stackoverflow.com/questions/28149634/what-does-the-xstartonfirstthread-vm-argument-do-mean
+javaOptions ++= (
+  if (System.getProperty("os.name").startsWith("Mac")) {
+    ("-XstartOnFirstThread") :: Nil,
+  } else {
+    Nil
+  }
+)
 libraryDependencies ++= Seq(
   // LWJGL
   "org.lwjgl" % "lwjgl" % lwjglVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
-ThisBuild / scalaVersion := "3.2.2"
+ThisBuild / scalaVersion := "3.3.1"
 fork := true
 
 lazy val root = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+// sbt-bloop, required for Bloop integration (used with VSCode)
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.15")

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: main
-

--- a/src/main/resources/glsl/2d-color.frag
+++ b/src/main/resources/glsl/2d-color.frag
@@ -5,12 +5,12 @@ uniform bool invertColor;
 uniform float opacity;
 
 in vec2 vTexCoord;
-
+out vec4 fragColor;
 void main() {
     float alpha = color.a * opacity;
     vec3 rgb = color.rgb;
     if (invertColor) {
         rgb = vec3(1.0) - rgb;
     }
-    gl_FragColor = vec4(rgb, alpha);
+    fragColor = vec4(rgb, alpha);
 }

--- a/src/main/resources/glsl/2d-color.frag
+++ b/src/main/resources/glsl/2d-color.frag
@@ -6,6 +6,7 @@ uniform float opacity;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
+
 void main() {
     float alpha = color.a * opacity;
     vec3 rgb = color.rgb;

--- a/src/main/resources/glsl/2d-texture.frag
+++ b/src/main/resources/glsl/2d-texture.frag
@@ -6,6 +6,7 @@ uniform float opacity;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
+
 void main() {
     vec4 color = texture(textureSampler, vTexCoord);
     float alpha = color.a * opacity;

--- a/src/main/resources/glsl/2d-texture.frag
+++ b/src/main/resources/glsl/2d-texture.frag
@@ -1,17 +1,17 @@
 #version 330
 
-uniform sampler2D texture;
+uniform sampler2D textureSampler;
 uniform bool invertColor;
 uniform float opacity;
 
 in vec2 vTexCoord;
-
+out vec4 fragColor;
 void main() {
-    vec4 color = texture2D(texture, vTexCoord);
+    vec4 color = texture(textureSampler, vTexCoord);
     float alpha = color.a * opacity;
     vec3 rgb = color.rgb;
     if (invertColor) {
         rgb = vec3(1.0) - rgb;
     }
-    gl_FragColor = vec4(rgb, alpha);
+    fragColor = vec4(rgb, alpha);
 }

--- a/src/main/resources/glsl/3d-color.frag
+++ b/src/main/resources/glsl/3d-color.frag
@@ -15,7 +15,7 @@ uniform vec3 normal;
 in vec3 viewPos;
 in float cameraDistance;
 in vec2 vTexCoord;
-
+out vec4 fragColor;
 float lightSteepness = 0.6f;
 float distanceSteepness = 10.0f;
 
@@ -58,5 +58,5 @@ void main() {
     }
 
     vec3 finalRGB = distanceFactor() * light;
-    gl_FragColor = vec4(finalRGB, alpha);
+    fragColor = vec4(finalRGB, alpha);
 }

--- a/src/main/resources/glsl/3d-color.frag
+++ b/src/main/resources/glsl/3d-color.frag
@@ -16,6 +16,7 @@ in vec3 viewPos;
 in float cameraDistance;
 in vec2 vTexCoord;
 out vec4 fragColor;
+
 float lightSteepness = 0.6f;
 float distanceSteepness = 10.0f;
 

--- a/src/main/resources/glsl/3d-texture.frag
+++ b/src/main/resources/glsl/3d-texture.frag
@@ -7,7 +7,7 @@ struct PointLight {
     float brightness;
 };
 
-uniform sampler2D texture;
+uniform sampler2D textureSampler;
 uniform PointLight pointLights[POINT_LIGHTS];
 uniform float ambientLightBrightness;
 uniform vec3 normal;
@@ -15,7 +15,7 @@ uniform vec3 normal;
 in vec3 viewPos;
 in float cameraDistance;
 in vec2 vTexCoord;
-
+out vec4 fragColor;
 float lightSteepness = 0.4f;
 float distanceSteepness = 10.0f;
 
@@ -48,7 +48,7 @@ vec3 getSpecularLight(vec3 rgb, PointLight pointLight) {
 }
 
 void main() {
-    vec4 color = texture2D(texture, vTexCoord);
+    vec4 color = texture(textureSampler, vTexCoord);
     float alpha = color.a;
     vec3 originalRGB = color.rgb;
 
@@ -59,5 +59,5 @@ void main() {
     }
 
     vec3 finalRGB = distanceFactor() * light;
-    gl_FragColor = vec4(finalRGB, alpha);
+    fragColor = vec4(finalRGB, alpha);
 }

--- a/src/main/resources/glsl/3d-texture.frag
+++ b/src/main/resources/glsl/3d-texture.frag
@@ -16,6 +16,7 @@ in vec3 viewPos;
 in float cameraDistance;
 in vec2 vTexCoord;
 out vec4 fragColor;
+
 float lightSteepness = 0.4f;
 float distanceSteepness = 10.0f;
 

--- a/src/main/scala/graphics/ShaderProgram.scala
+++ b/src/main/scala/graphics/ShaderProgram.scala
@@ -100,14 +100,14 @@ class ShaderProgram(
         glDetachShader(programHandle, fragmentShaderHandle)
       }
     }
-    // Validate program
-    glCheck { glValidateProgram(programHandle) }
-    // Check for errors
-    if glGetProgrami(programHandle, GL_VALIDATE_STATUS) == 0 then {
-      throw new Exception(
-        s"Failed to link shader program:\n${glGetProgramInfoLog(programHandle, 1024)}",
-      )
-    }
+    // Validate program (only for debugging, validateprogram requires a valid context with VBAO bound)
+    //   glCheck { glValidateProgram(programHandle) }
+    //   // Check for errors
+    //  if glGetProgrami(programHandle, GL_VALIDATE_STATUS) == 0 then {
+    //    throw new Exception(
+    //      s"Failed to link shader program:\n${glGetProgramInfoLog(programHandle, 1024)}",
+    //    )
+    //  }
   }
 
   private def findUniformHandles(): immutable.Map[String, Int] = {

--- a/src/main/scala/graphics/Window.scala
+++ b/src/main/scala/graphics/Window.scala
@@ -49,6 +49,10 @@ class Window(val title: String, var width: Int, var height: Int) {
 
     // Enable window hints
     glfwDefaultWindowHints()
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3)
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3)
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE)
+
     // Keep the window hidden after creation
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE)
     // Prepare buffer for MSAA


### PR DESCRIPTION
- Add M1 mac support, previously the `build.sbt` didn't take into account CPU-architecture nor the special JVM flag `-XstartOnFirstThread` needed for GWT applications on Mac. 
- Updated shader code to be correct OpenGL 3.3 (wouldn't compile on my machine without these changes.
- Update sbt and scala version to enable Java 21 support

Tested this on both Windows x86_64 and my M1 Macbook Pro (MacOS arm64), don't have a Linux with a DE around so can't test that unfortunately